### PR TITLE
Add Weemos D1 mini 32 as target

### DIFF
--- a/ESP32_AP-Flasher/platformio.ini
+++ b/ESP32_AP-Flasher/platformio.ini
@@ -250,3 +250,34 @@ build_flags =
 	-D FLASHER_LED=19
 build_src_filter = 
    +<*>-<usbflasher.cpp>-<serialconsole.cpp>
+
+
+[env:Weemos_AP]
+board = wemos_d1_mini32
+board_build.partitions = default.csv
+
+build_flags = 
+	-D BUILD_ENV_NAME=$PIOENV
+	-D BUILD_TIME=$UNIX_TIME
+	-D CORE_DEBUG_LEVEL=0
+
+	-D FLASHER_AP_SS=5
+	-D FLASHER_AP_CLK=18
+	-D FLASHER_AP_MOSI=23
+	-D FLASHER_AP_MISO=19
+	-D FLASHER_AP_RESET=14
+	-D FLASHER_AP_POWER={-1}
+	-D FLASHER_AP_TEST=-1
+	-D FLASHER_AP_TXD=16
+	-D FLASHER_AP_RXD=17
+	-D FLASHER_LED=22
+
+	-D USER_SETUP_LOADED
+	-D DISABLE_ALL_LIBRARY_WARNINGS
+	-D ILI9341_DRIVER
+	-D SMOOTH_FONT
+	-D LOAD_FONT2
+
+build_src_filter = 
+   +<*>-<usbflasher.cpp>-<serialconsole.cpp>
+   


### PR DESCRIPTION
The original weemos D1 mini was one of the most popular ESP8266 boards. To this day many designs are designed around its formfactor.
The successor is the here added D1 mini 32. It brings the same "core" header with 8 GPIO but also additional io.

We are adding a default config which is workable with the old pinconfig as those are usually the only ones exposed on the breakout boards.