### PR TITLE
Add M5stack (original core) config

### DIFF
--- a/ESP32_AP-Flasher/platformio.ini
+++ b/ESP32_AP-Flasher/platformio.ini
@@ -250,3 +250,43 @@ build_flags =
 	-D FLASHER_LED=19
 build_src_filter = 
    +<*>-<usbflasher.cpp>-<serialconsole.cpp>
+
+[env:M5Stack_Core_ONE_AP]
+platform = espressif32
+board = m5stack-core-esp32
+board_build.partitions = esp32_sdcard.csv
+
+build_flags = 
+	-D BUILD_ENV_NAME=$PIOENV
+	-D BUILD_TIME=$UNIX_TIME
+	-D CORE_DEBUG_LEVEL=0
+	
+	-D HAS_SDCARD
+	-D USE_SOFTSPI
+	-D SD_CARD_SS=4
+	-D SD_CARD_CLK=18
+	-D SD_CARD_MISO=19
+	-D SD_CARD_MOSI=23
+
+	-D FLASHER_AP_SS=5
+	-D FLASHER_AP_CLK=36
+	-D FLASHER_AP_MOSI=26
+	-D FLASHER_AP_MISO=35
+	-D FLASHER_AP_RESET=2
+	-D FLASHER_AP_POWER={-1}
+	-D FLASHER_AP_TEST=-1
+
+	-D FLASHER_AP_TXD=16
+	-D FLASHER_AP_RXD=17
+
+	-D FLASHER_LED=-1
+	-D FLASH_TIMEOUT=10
+
+	-D USER_SETUP_LOADED
+	-D DISABLE_ALL_LIBRARY_WARNINGS
+	-D ILI9341_DRIVER
+	-D SMOOTH_FONT
+	-D LOAD_FONT2
+build_src_filter = 
+   +<*>-<usbflasher.cpp>-<serialconsole.cpp>
+   


### PR DESCRIPTION
The M5stack board offers three interesting features for use with OpenEPaperLink:
- LCD
- SDCard slot
- Modules including a batters

Which means it can easily be used to walk around with an AP for testing purposes.
The LCD is currely not used as the M5Stack library is so old that it collides with newer versions of eTFT which we are importing already.