### PR TITLE
Misc fixes

### DIFF
--- a/ESP32_AP-Flasher/data/www/main.js
+++ b/ESP32_AP-Flasher/data/www/main.js
@@ -94,7 +94,7 @@ function connect() {
 			processTags(msg.tags);
 		}
 		if (msg.sys) {
-			$('#sysinfo').innerHTML = 'free heap: ' + msg.sys.heap + ' bytes &#x2507; db size: ' + msg.sys.dbsize + ' bytes &#x2507; db record count: ' + msg.sys.recordcount + ' &#x2507; filesystem free: ' + convertSize(msg.sys.littlefsfree);
+			$('#sysinfo').innerHTML = 'free heap: ' + msg.sys.heap + ' bytes &#x2507; db size: ' + convertSize(msg.sys.dbsize) + " ("+ msg.sys.dbsize + ' bytes) &#x2507; db record count: ' + msg.sys.recordcount + ' &#x2507; filesystem free: ' + convertSize(msg.sys.littlefsfree);
 			if (msg.sys.apstate) {
 				$("#apstatecolor").style.color = apstate[msg.sys.apstate].color;
 				$("#apstate").innerHTML = apstate[msg.sys.apstate].state;

--- a/ESP32_AP-Flasher/platformio.ini
+++ b/ESP32_AP-Flasher/platformio.ini
@@ -27,6 +27,13 @@ board_build.filesystem = littlefs
 monitor_filters = esp32_exception_decoder
 monitor_speed = 115200
 board_build.f_cpu = 240000000L
+build_flags =
+	-D BUILD_ENV_NAME=$PIOENV
+	-D BUILD_TIME=$UNIX_TIME
+	-D USER_SETUP_LOADED
+	-D DISABLE_ALL_LIBRARY_WARNINGS
+	-D ILI9341_DRIVER
+	-D SMOOTH_FONT
 
 ; ----------------------------------------------------------------------------------------
 ; !!! this configuration expects the Mini_AP
@@ -39,8 +46,7 @@ board_build.partitions = default.csv
 build_unflags =
   -D CONFIG_MBEDTLS_INTERNAL_MEM_ALLOC=y
 build_flags = 
-	-D BUILD_ENV_NAME=$PIOENV
-	-D BUILD_TIME=$UNIX_TIME
+	${env.build_flags}
 	-D OPENEPAPERLINK_MINI_AP_PCB
 	-D ARDUINO_USB_MODE=0
 	-D CONFIG_SPIRAM_USE_MALLOC=1
@@ -59,10 +65,6 @@ build_flags =
   	-D FLASHER_AP_TEST=12
   	-D FLASHER_LED=15
   	-D FLASHER_RGB_LED=33
-	-D USER_SETUP_LOADED
-	-D DISABLE_ALL_LIBRARY_WARNINGS
-	-D ILI9341_DRIVER
-	-D SMOOTH_FONT
 build_src_filter = 
    +<*>-<usbflasher.cpp>-<serialconsole.cpp>
 board_build.psram_type=qspi_opi
@@ -81,8 +83,7 @@ board_build.partitions = default.csv
 build_unflags =
   -D CONFIG_MBEDTLS_INTERNAL_MEM_ALLOC=y
 build_flags = 
-	-D BUILD_ENV_NAME=$PIOENV
-	-D BUILD_TIME=$UNIX_TIME
+	${env.build_flags}
 	-D OPENEPAPERLINK_NANO_AP_PCB
 	-D ARDUINO_USB_MODE=0
 	-D CONFIG_SPIRAM_USE_MALLOC=1
@@ -99,10 +100,6 @@ build_flags =
   	-D FLASHER_AP_TEST=36
   	-D FLASHER_LED=15
   	-D FLASHER_RGB_LED=-1
-	-D USER_SETUP_LOADED
-	-D DISABLE_ALL_LIBRARY_WARNINGS
-	-D ILI9341_DRIVER
-	-D SMOOTH_FONT
 build_src_filter = 
    +<*>-<usbflasher.cpp>-<serialconsole.cpp>
 board_build.psram_type=qspi_opi
@@ -122,8 +119,7 @@ build_unflags =
   -D ARDUINO_USB_MODE=1
   -D CONFIG_MBEDTLS_INTERNAL_MEM_ALLOC=y
 build_flags = 
-	-D BUILD_ENV_NAME=$PIOENV
-	-D BUILD_TIME=$UNIX_TIME
+	${env.build_flags}
 	-D OPENEPAPERLINK_PCB
 	-D ARDUINO_USB_MODE=0
 	-D CONFIG_ESP32S3_SPIRAM_SUPPORT=1
@@ -163,10 +159,6 @@ build_flags =
 	-D FLASHER_ALT_TEST=13
 	-D FLASHER_LED=21
 	-D FLASHER_RGB_LED=48
-	-D USER_SETUP_LOADED
-	-D DISABLE_ALL_LIBRARY_WARNINGS
-	-D ILI9341_DRIVER
-	-D SMOOTH_FONT
 board_build.flash_mode=qio
 board_build.arduino.memory_type = qio_opi
 board_build.psram_type=qspi_opi
@@ -182,8 +174,7 @@ board_upload.flash_size = 16MB
 board = esp32dev
 board_build.partitions = default.csv
 build_flags = 
-	-D BUILD_ENV_NAME=$PIOENV
-	-D BUILD_TIME=$UNIX_TIME
+	${env.build_flags}
 	-D CORE_DEBUG_LEVEL=0
 	-D SIMPLE_AP
 	-D FLASHER_AP_SS=5
@@ -196,10 +187,6 @@ build_flags =
 	-D FLASHER_AP_TXD=17
 	-D FLASHER_AP_RXD=16
 	-D FLASHER_LED=22
-	-D USER_SETUP_LOADED
-	-D DISABLE_ALL_LIBRARY_WARNINGS
-	-D ILI9341_DRIVER
-	-D SMOOTH_FONT
 build_src_filter = 
    +<*>-<usbflasher.cpp>-<serialconsole.cpp>
 
@@ -211,8 +198,7 @@ build_src_filter =
 board = wemos_d1_mini32
 board_build.partitions = default.csv
 build_flags = 
-	-D BUILD_ENV_NAME=$PIOENV
-	-D BUILD_TIME=$UNIX_TIME
+	${env.build_flags}
 	-D CORE_DEBUG_LEVEL=0
 
 	-D POWER_NO_SOFT_POWER
@@ -227,10 +213,6 @@ build_flags =
 	-D FLASHER_AP_TXD=16
 	-D FLASHER_AP_RXD=17
 	-D FLASHER_LED=22
-	-D USER_SETUP_LOADED
-	-D DISABLE_ALL_LIBRARY_WARNINGS
-	-D ILI9341_DRIVER
-	-D SMOOTH_FONT
 build_src_filter = 
    +<*>-<usbflasher.cpp>-<serialconsole.cpp>
 
@@ -243,8 +225,7 @@ platform = espressif32
 board = m5stack-core-esp32
 board_build.partitions = esp32_sdcard.csv
 build_flags = 
-	-D BUILD_ENV_NAME=$PIOENV
-	-D BUILD_TIME=$UNIX_TIME
+	${env.build_flags}
 	-D CORE_DEBUG_LEVEL=0
 
 	-D POWER_NO_SOFT_POWER

--- a/ESP32_AP-Flasher/push_ota.sh
+++ b/ESP32_AP-Flasher/push_ota.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+source updateRemote.sh > /dev/null
+
+if [ -z "$IP" ]
+  then
+    echo "ERROR: Empty IP variable"
+    exit 1
+fi
+
+if [ -z "$PIOENV" ]
+  then
+    echo "ERROR: Empty PIOENV variable"
+    exit 1
+fi
+
+md5sum .pio/build/$PIOENV/firmware.bin | tee .pio/build/$PIOENV/firmware.md5
+upload_file .pio/build/$PIOENV/firmware.md5:ota_md5.txt
+upload_file .pio/build/$PIOENV/firmware.bin:ota.bin

--- a/ESP32_AP-Flasher/src/web.cpp
+++ b/ESP32_AP-Flasher/src/web.cpp
@@ -127,15 +127,25 @@ void wsErr(String text) {
     if (wsMutex) xSemaphoreGive(wsMutex);
 }
 
+size_t dbSize(){
+    size_t size = tagDB.size() * sizeof(tagRecord);
+    for(auto &tag : tagDB) {
+        if (tag->data)
+            size += tag->len;
+        size += tag->modeConfigJson.length();
+    }
+    return size;
+}
+
 void wsSendSysteminfo() {
-    DynamicJsonDocument doc(150);
+    DynamicJsonDocument doc(250);
     JsonObject sys = doc.createNestedObject("sys");
     time_t now;
     time(&now);
     sys["currtime"] = now;
     sys["heap"] = ESP.getFreeHeap();
     sys["recordcount"] = tagDB.size();
-    sys["dbsize"] = tagDB.size() * sizeof(tagRecord);
+    sys["dbsize"] = dbSize();
     sys["littlefsfree"] = Storage.freeSpace();
     sys["apstate"] = apInfo.state;
     sys["runstate"] = config.runStatus;

--- a/ESP32_AP-Flasher/updateRemote.sh
+++ b/ESP32_AP-Flasher/updateRemote.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+(return 0 2>/dev/null) && sourced=1 || sourced=0
+
+if [ $sourced -eq 0 ]; then
+	if [ $# -eq 0 ]
+	  then
+	    echo "No IP address provided"
+		exit 1
+	fi
+
+	IP=$1
+
+	if [ -z "$IP" ]
+	  then
+	    echo "ERROR: Empty IP"
+		exit 1
+fi
+fi
+upload_file () {
+	for file in "$@"
+	do
+		split=( $(echo $file  | tr ":" " ") )
+		echo $split
+		filename=${split[0]}
+		if [ -z  ${split[1]} ]; then
+			filepath=$(echo ${filename} | cut -d'/' -f2-)
+		else
+			filepath=${split[1]}
+		fi
+		echo $filename "-->" $filepath
+
+		curl "http://${IP}/edit" -X POST \
+		-H "Origin: http://${IP}" \
+		-H 'Connection: keep-alive' \
+		-H "Referer: http://${IP}/edit" \
+		-F "data=@${filename};filename=\"${filepath}\""
+		echo ""
+	done
+}
+
+export -f upload_file
+
+if [ $sourced -eq 0 ]; then
+	export IP
+	find data -type f -exec bash -c "upload_file {} $IP" \;
+else
+	echo "You can now call "
+	echo "IP=1.2.3.4 upload_file data/file1.txt data/file2.txt:target.txt"
+fi


### PR DESCRIPTION
- Fix: Properly calculate db size for SystemInfo

So far the calculated size for the tagDB in the frontend was
purely based on the size of each of its static entries.
However the data pointer as well as the json based config string
can occupy additional memory which is not accounted for.

We are therefore introducing a helper function to properly
calculate the DBs size.

-     platform-io.ini:     Refactor build flags
-     Add updateRemote.sh script to update the contentFs on multiple APs at once