### PR TITLE
Make path to `soc/lp_uart_reg.{c,h}` consistent

### DIFF
--- a/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/main.c
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/main.c
@@ -21,7 +21,7 @@
 #include "sdkconfig.h"
 #include "second_uart.h"
 #include "soc/uart_struct.h"
-#include "soc\lp_uart_reg.h"
+#include "soc/lp_uart_reg.h"
 #include "utils.h"
 #include "led.h"
 

--- a/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/radio.c
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/radio.c
@@ -17,7 +17,7 @@
 #include "proto.h"
 #include "sdkconfig.h"
 #include "soc/uart_struct.h"
-#include "soc\lp_uart_reg.h"
+#include "soc/lp_uart_reg.h"
 #include "radio.h"
 #include "utils.h"
 #include "led.h"

--- a/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/second_uart.c
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/second_uart.c
@@ -19,7 +19,7 @@
 #include "proto.h"
 #include "sdkconfig.h"
 #include "soc/uart_struct.h"
-#include "soc\lp_uart_reg.h"
+#include "soc/lp_uart_reg.h"
 
 static const char *TAG = "SECOND_UART";
 

--- a/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/utils.c
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/utils.c
@@ -17,7 +17,7 @@
 #include "proto.h"
 #include "sdkconfig.h"
 #include "soc/uart_struct.h"
-#include "soc\lp_uart_reg.h"
+#include "soc/lp_uart_reg.h"
 #include "nvs_flash.h"
 
 void delay(int ms) { vTaskDelay(pdMS_TO_TICKS(ms)); }


### PR DESCRIPTION
Using _just_ the `/` character makes the paths "universal".

On *nix, `/` is the path separator and windows has support for `/` internally.

This addresses #117 