### PR TITLE
Fix openepaperlink.eu proxy on https proxies

### DIFF
--- a/ESP32_AP-Flasher/wwwroot/ota.js
+++ b/ESP32_AP-Flasher/wwwroot/ota.js
@@ -167,7 +167,7 @@ export async function updateWebpage(fileUrl, tagname, showReload) {
 
                 print("Updating littleFS partition...");
 
-                fetch("http://openepaperlink.eu/getupdate/?url=" + fileUrl)
+                fetch(location.protocol + "//openepaperlink.eu/getupdate/?url=" + fileUrl)
                     .then(response => response.json())
                     .then(data => {
                         checkfiles(data);
@@ -271,7 +271,7 @@ export async function updateESP(fileUrl, showConfirm) {
 
     while (retryCount < maxRetries) {
         try {
-            const response = await fetch("http://openepaperlink.eu/getupdate/?url=" + fileUrl + "&env=" + env);
+            const response = await fetch(location.protocol + "//openepaperlink.eu/getupdate/?url=" + fileUrl + "&env=" + env);
             const responseBody = await response.text();
             if (!response.ok) {
                 throw new Error("Network response was not OK: " + responseBody);
@@ -284,7 +284,7 @@ export async function updateESP(fileUrl, showConfirm) {
             const data = JSON.parse(responseBody);
             const file = data.find((entry) => entry.name == env + '.bin');
             if (file) {
-                binurl = "http://openepaperlink.eu/getupdate/?url=" + encodeURIComponent(file.url);
+                binurl = location.protocol + "//openepaperlink.eu/getupdate/?url=" + encodeURIComponent(file.url);
                 binmd5 = file.md5;
                 binsize = file.size;
                 console.log(`URL for "${file.name}": ${binurl}`);
@@ -389,7 +389,7 @@ $('#selectRepo').onclick = function (event) {
                 const filesJsonAsset = assets.find(asset => asset.name === 'filesystem.json');
                 const binariesJsonAsset = assets.find(asset => asset.name === 'binaries.json');
                 if (filesJsonAsset && binariesJsonAsset) {
-                    const updateUrl = "http://openepaperlink.eu/getupdate/?url=" + binariesJsonAsset.browser_download_url + "&env=" + $('#repo').value;
+                    const updateUrl = location.protocol + "//openepaperlink.eu/getupdate/?url=" + binariesJsonAsset.browser_download_url + "&env=" + $('#repo').value;
                     return fetch(updateUrl);
                 } else {
                     throw new Error("Json file binaries.json and/or filesystem.json not found in the release assets");

--- a/ESP32_AP-Flasher/wwwroot/ota.js
+++ b/ESP32_AP-Flasher/wwwroot/ota.js
@@ -167,7 +167,7 @@ export async function updateWebpage(fileUrl, tagname, showReload) {
 
                 print("Updating littleFS partition...");
 
-                fetch(location.protocol + "//openepaperlink.eu/getupdate/?url=" + fileUrl)
+                fetch("//openepaperlink.eu/getupdate/?url=" + fileUrl)
                     .then(response => response.json())
                     .then(data => {
                         checkfiles(data);
@@ -271,7 +271,7 @@ export async function updateESP(fileUrl, showConfirm) {
 
     while (retryCount < maxRetries) {
         try {
-            const response = await fetch(location.protocol + "//openepaperlink.eu/getupdate/?url=" + fileUrl + "&env=" + env);
+            const response = await fetch("//openepaperlink.eu/getupdate/?url=" + fileUrl + "&env=" + env);
             const responseBody = await response.text();
             if (!response.ok) {
                 throw new Error("Network response was not OK: " + responseBody);
@@ -284,7 +284,7 @@ export async function updateESP(fileUrl, showConfirm) {
             const data = JSON.parse(responseBody);
             const file = data.find((entry) => entry.name == env + '.bin');
             if (file) {
-                binurl = location.protocol + "//openepaperlink.eu/getupdate/?url=" + encodeURIComponent(file.url);
+                binurl = "http://openepaperlink.eu/getupdate/?url=" + encodeURIComponent(file.url);
                 binmd5 = file.md5;
                 binsize = file.size;
                 console.log(`URL for "${file.name}": ${binurl}`);
@@ -389,7 +389,7 @@ $('#selectRepo').onclick = function (event) {
                 const filesJsonAsset = assets.find(asset => asset.name === 'filesystem.json');
                 const binariesJsonAsset = assets.find(asset => asset.name === 'binaries.json');
                 if (filesJsonAsset && binariesJsonAsset) {
-                    const updateUrl = location.protocol + "//openepaperlink.eu/getupdate/?url=" + binariesJsonAsset.browser_download_url + "&env=" + $('#repo').value;
+                    const updateUrl = "//openepaperlink.eu/getupdate/?url=" + binariesJsonAsset.browser_download_url + "&env=" + $('#repo').value;
                     return fetch(updateUrl);
                 } else {
                     throw new Error("Json file binaries.json and/or filesystem.json not found in the release assets");


### PR DESCRIPTION
Browser don't like to make http request when on a https connection. This fixes that. We probably could also always make a https connection, but that might cause issues if e.g. the server certificate runs out. Then at least local http access will still work.

The file editor does not work yet, I hope to fix it in the future.