### PR TITLE
Update SDCC build script to support SDCC's trunk

### DIFF
--- a/sdcc/README.md
+++ b/sdcc/README.md
@@ -1,4 +1,4 @@
-This subdirectory contains scripts to build the correct version of SDCC (4.2.0) for compiling 8051 based firmware.
+This subdirectory contains scripts to build the correct version of SDCC (4.2.0) for compiling 8051 based firmware on Linux.
 
 To use simply source setup_sdcc.sh before building.  The first time setup_sdcc.sh is run proper version of SDCC sources will be checkout from github and built locally.
 Finally the environment variable CC will be set to 'sdcc' and the path to the local version of sdcc will be added to the beginning of the path.

--- a/sdcc/build_sdcc.sh
+++ b/sdcc/build_sdcc.sh
@@ -1,41 +1,55 @@
 #/bin/sh
 # build local version of sdcc from source
 
+#set -x
 SDCC_VER=${1:-4.2.0}
+SDCC_DIR=sdcc-${SDCC_VER}
 
-if [ ! -e sdcc ]; then
-   git clone https://github.com/swegener/sdcc.git
-   if [ $? -ne 0 ]; then
-      echo "Couldn't clone https://github.com/swegener/sdcc.git"
-      exit 1
-   fi
-  cd sdcc
-  git tag 4.2.0 56dc646f8ba6d37c039c5e0c3e60b1340da65b9f
-  git tag 4.0.7 6f1f08a07fc7a05b06e7a2594a930d8984ba817a
+echo "Building ${SDCC_DIR}, please be patient this is going to take a while!"
+
+if [ ! -e build ]; then
+   mkdir build
+fi
+cd build
+if [ ${SDCC_VER} = "trunk" ]; then
+   SDCC_DIR="trunk"
+   SVN_URL="svn://svn.code.sf.net/p/sdcc/code/trunk"
 else
-  cd sdcc
+   SVN_URL="svn://svn.code.sf.net/p/sdcc/code/tags/${SDCC_DIR}"
 fi
 
-git checkout ${SDCC_VER}
+echo -n "Checking out ${SDCC_DIR} source ..."
+svn checkout ${SVN_URL} > /dev/null
+echo
 if [ $? -ne 0 ]; then
-  echo "Couldn't checkout ${SDCC_VER} source from git"
+  echo "Couldn't checkout ${SVN_URL}"
   exit 1
 fi
 
-./configure --prefix=`pwd`/../sdcc-${SDCC_VER} --disable-z80-port --disable-z180-port --disable-r2k-port --disable-r2ka-port --disable-r3ka-port --disable-sm83-port --disable-tlcs90-port --disable-ez80_z80-port --disable-z80n-port --disable-ds390-port --disable-ds400-port --disable-pic14-port --disable-pic16-port --disable-hc08-port --disable-s08-port --disable-stm8-port --disable-pdk13-port --disable-pdk14-port --disable-pdk15-port --disable-pdk16-port --disable-mos6502-port --disable-mos65c02-port 2>&1 | tee build.log
-make -j8  2>&1 | tee -a build.log
+cd ${SDCC_DIR}/sdcc
+CWD=`pwd`
+echo -n "Configuring ..."
+./configure --prefix=${CWD}/../../../sdcc-${SDCC_VER} --disable-z80-port --disable-z180-port --disable-r2k-port --disable-r2ka-port --disable-r3ka-port --disable-sm83-port --disable-tlcs90-port --disable-ez80_z80-port --disable-z80n-port --disable-ds390-port --disable-ds400-port --disable-pic14-port --disable-pic16-port --disable-hc08-port --disable-s08-port --disable-stm8-port --disable-pdk13-port --disable-pdk14-port --disable-pdk15-port --disable-pdk16-port --disable-mos6502-port --disable-mos65c02-port > build.log 2>&1 
+echo
 if [ $? -ne 0 ]; then
-  echo "sdcc make failed see ./sdcc/build.log for details"
+  echo "configure failed see ${CWD}/build.log for details"
   exit 1
 fi
-
-make -j8  install 2>&1 | tee -a build.log
-if [ $? -ne 0 ]; then
-  echo "sdcc make install failed see ./sdcc/build.log for details"
+echo -n "Compiling ..."
+make -j8 >> build.log 2>&1
+status=$?
+if [ $status  -ne 0 ]; then
+  echo "sdcc make failed (${status}) see ${CWD}/build.log for details"
   exit 1
 fi
-make clean
-git reset HEAD --hard
-git clean -f -d -x
-
+echo
+echo -n "Installing ..."
+make -j8  install >> build.log 2>&1 
+if [ $? -ne 0 ]; then
+  echo "sdcc make install failed see ${CWD}/build.log for details"
+  exit 1
+fi
+#echo "Cleaning up ..."
+#cd ../../..
+#rm -rf build
 


### PR DESCRIPTION
1. Changed source repo from github mirror to SDCC's master SVN repo.
2. Added support for building the trunk as well as named tags.