### PR TITLE
Add display of subGhz channel to LCD when subGhz radio is present.

### DIFF
--- a/ESP32_AP-Flasher/src/web.cpp
+++ b/ESP32_AP-Flasher/src/web.cpp
@@ -110,7 +110,22 @@ void wsSendSysteminfo() {
         setVarDB("ap_date", timeBuffer);
     }
     setVarDB("ap_ip", WiFi.localIP().toString());
+
+#ifdef HAS_SUBGHZ
+    String ApChanString = String(apInfo.channel);
+    if(apInfo.hasSubGhz) {
+       ApChanString += ", SubGhz ";
+       if(apInfo.SubGhzChannel == 0) {
+          ApChanString += "disabled";
+       }
+       else {
+          ApChanString += "Ch " + String(apInfo.SubGhzChannel);
+       }
+    }
+    setVarDB("ap_ch", ApChanString);
+#else
     setVarDB("ap_ch", String(apInfo.channel));
+#endif
 
     // reboot once at night
     if (timeinfo.tm_hour == 4 && timeinfo.tm_min == 0 && millis() > 2 * 3600 * 1000) {


### PR DESCRIPTION
Format:

No change if CC1110 radio is not detected.

Detected and disabled
![subghz_disabled](https://github.com/jjwbruijn/OpenEPaperLink/assets/4642629/ea92b37f-cd9f-4865-8f95-b52ebacbf298)

Detected and channel set
![subghz_enabled](https://github.com/jjwbruijn/OpenEPaperLink/assets/4642629/fe71f530-9dd9-4b6a-b76e-9a7f78ea1e61)



