### PR TITLE
SubGhz radio fixes.

### DIFF
--- a/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/cc1101_radio.c
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/cc1101_radio.c
@@ -142,10 +142,16 @@ enum RFSTATE {
 
 // IOCFG2 GDO2: high when TX FIFO at or above the TX FIFO threshold
 #define CC1101_DEFVAL_IOCFG2           0x02
+
+// IOCFG1 GDO1: High impedance (3-state)
 #define CC1101_DEFVAL_IOCFG1           0x2E
-// GDO0 Asserts when sync word has been sent / received, and 
-// de-asserts at the end of the packet.
+
+// GDO0 goes high when sync word has been sent / received, and 
+// goes low at the end of the packet.
+// In TX mode the pin will go low if the TX FIFO underflows.
 #define CC1101_DEFVAL_IOCFG0           0x06
+
+// Threshold = 32 bytes (1/2 of FIFO len)
 #define CC1101_DEFVAL_FIFOTHR          0x07
 #define CC1101_DEFVAL_RCCTRL1          0x41
 #define CC1101_DEFVAL_RCCTRL0          0x00

--- a/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/main.c
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/main.c
@@ -668,6 +668,11 @@ void sendBlockData() {
                 partNo++;
             }
         }
+        if(dstPan == PROTO_PAN_ID_SUBGHZ) {
+        // Don't send BLOCK_MAX_PARTS for subgig, it requests what it 
+        // can handle with its limited RAM
+           break;
+        }
     }
 }
 void sendXferCompleteAck(uint8_t *dst) {
@@ -734,7 +739,7 @@ void app_main(void) {
 
     radio_init(curChannel);
 #ifdef CONFIG_OEPL_SUBGIG_SUPPORT
-    if(!SubGig_radio_init(curSubGhzChannel)) {
+    if(SubGig_radio_init(curSubGhzChannel)) {
     // Ether we don't have a cc1101 or it's not working
        curSubGhzChannel = NO_SUBGHZ_CHANNEL; 
        ESP_LOGI(TAG,"CC1101 NOT detected.");

--- a/ESP32_AP-Flasher/platformio.ini
+++ b/ESP32_AP-Flasher/platformio.ini
@@ -434,6 +434,7 @@ build_flags =
 	-D SERIAL_FLASHER_BOOT_HOLD_TIME_MS=200
 	-D SERIAL_FLASHER_RESET_HOLD_TIME_MS=200
 	-D C6_OTA_FLASHING
+        -D HAS_SUBGHZ
 build_src_filter = 
 	+<*>
 board_build.flash_mode=qio


### PR DESCRIPTION
1. Don't force sending of BLOCK_MAX_PARTS parts for subGhz.
2. Fix CC1101 module detection logic.
3. Mitigate for lost CC1101 interrupts.