### PR TITLE
New firmware hash found for ST-GR2900N.

### DIFF
--- a/ESP32_AP-Flasher/data/tag_md5_db.json
+++ b/ESP32_AP-Flasher/data/tag_md5_db.json
@@ -106,5 +106,14 @@
       "MD5":"4643F4F74321FC9B4F9F0ECBD93B74AB",
       "type":17,
       "note":"2.9 White + NFC UC8151 V025 FW"
+    },
+    {
+      "name":"2.9 White + NFC UC8151",
+      "mac_offset":64518,
+      "mac_format":1,
+      "mac_suffix":"3B30",
+      "MD5":"3962F17C657B1E77E144E69DFD1D35A5",
+      "type":17,
+      "note":"2.9 White + NFC UC8151 V033 FW"
     }
   ]


### PR DESCRIPTION
I found this SOLUM SEM9110 based tag, that was not supported by the ESP32 flasher. Its MD5 hash was simply missing in the tag_md5_db.json. This PR adds the hash to the library. I have tested it and flashed a ESP32S2 based Nano AP.

An image of the tags label is attached below.

The label says:
MSIP - CRM - SLU - ST - GR2900N
FCC ID: 2AFWN - ST - GM29XX2N
MODEL: ST - GR29000
MAC: 0282E0983B1E

![IMG_20251017_214342](https://github.com/user-attachments/assets/30afcdcc-ade2-458a-933b-c3641fd9eb15)
