### PR TITLE
Fix buffer size truncation for non-8-aligned image dimensions

### DIFF
--- a/ESP32_AP-Flasher/src/makeimage.cpp
+++ b/ESP32_AP-Flasher/src/makeimage.cpp
@@ -461,7 +461,7 @@ void spr2buffer(TFT_eSprite &spr, String &fileout, imgParam &imageParams) {
         case 1:
         case 2: {
             long bufw = spr.width(), bufh = spr.height();
-            size_t buffer_size = (bufw * bufh) / 8;
+            size_t buffer_size = ((bufw * bufh) + 7) / 8;  // round up: not all dimensions are multiples of 8
 #ifdef BOARD_HAS_PSRAM
             uint8_t *buffer = (uint8_t *)ps_malloc(buffer_size);
 #else
@@ -585,7 +585,7 @@ void spr2buffer(TFT_eSprite &spr, String &fileout, imgParam &imageParams) {
         case 3:
         case 4: {
             long bufw = spr.width(), bufh = spr.height();
-            size_t buffer_size = (bufw * bufh) / 8 * imageParams.bpp;
+            size_t buffer_size = ((bufw * bufh) + 7) / 8 * imageParams.bpp;
             uint8_t *buffer = (uint8_t *)ps_malloc(buffer_size);
             if (!buffer) {
                 Serial.println("Failed to allocate buffer");


### PR DESCRIPTION
Integer division (w*h)/8 truncates when w*h is not a multiple of 8, allocating one byte too few. spr2color then writes past the end of the buffer, corrupting the heap. Use (w*h+7)/8 to round up correctly.

Triggered by any tag whose width*height is not divisible by 8.