### PR TITLE
Honor LED off setting for yellow AP activity pulse

### DIFF
--- a/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/compile.sh
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/compile.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Build the ESP32-C6 AP firmware. Shell port of compile.ps1.
+#
+# Sources the ESP-IDF environment and runs a clean build. Expects ESP-IDF in
+# the default ~/esp/esp-idf location (as compile.ps1 does); set IDF_EXPORT to
+# point at a different export.sh.
+
+IDF_EXPORT="${IDF_EXPORT:-$HOME/esp/esp-idf/export.sh}"
+
+cd "$(dirname "$0")" || exit 1
+
+# shellcheck source=/dev/null
+. "$IDF_EXPORT"
+
+idf.py fullclean
+idf.py build

--- a/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/led.c
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/led.c
@@ -15,6 +15,12 @@
 const gpio_num_t led_pins[NUM_LEDS] = {LED1, LED2};
 TimerHandle_t led_timers[NUM_LEDS] = {0};
 
+static bool activity_led_enabled = true;
+
+void led_set_activity_enabled(bool enabled) {
+	activity_led_enabled = enabled;
+}
+
 void led_timer_callback(TimerHandle_t xTimer) {
 	int led_index = (int)pvTimerGetTimerID(xTimer);
 	if (led_index >= 0 && led_index < NUM_LEDS) {
@@ -37,6 +43,7 @@ void init_led() {
 }
 
 void led_flash(int nr) {
+	if (!activity_led_enabled) return;
 	gpio_set_level(led_pins[nr], 1);
 	if (nr >= 0 && nr < NUM_LEDS) {
 		xTimerStart(led_timers[nr], 0);

--- a/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/led.h
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/led.h
@@ -4,3 +4,4 @@
 void init_led();
 void led_set(int nr, bool state);
 void led_flash(int nr);
+void led_set_activity_enabled(bool enabled);

--- a/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/main.c
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/main.c
@@ -352,6 +352,7 @@ void     processSerial(uint8_t lastchar) {
             if (bytesRemain == 0) {
                 if (checkCRC(serialbuffer, sizeof(struct espSetChannelPower))) {
                    struct espSetChannelPower *scp = (struct espSetChannelPower *) serialbuffer;
+                    led_set_activity_enabled((scp->flags & ESP_SCP_FLAG_LED) != 0);
 #ifdef CONFIG_OEPL_SUBGIG_SUPPORT
                     if(curSubGhzChannel != scp->subghzchannel
                        && curSubGhzChannel != NO_SUBGHZ_CHANNEL)

--- a/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/proto.h
+++ b/ARM_Tag_FW/OpenEPaperLink_esp32_C6_AP/main/proto.h
@@ -179,10 +179,15 @@ struct espAvailDataReq {
     struct AvailDataReq adr;
 } __attribute__((packed, aligned(1)));
 
+// flags bit 0: the host mirrors its LED on/off setting here so we can silence
+// our own activity LED. Other bits reserved.
+#define ESP_SCP_FLAG_LED (1 << 0)
+
 struct espSetChannelPower {
     uint8_t checksum;
     uint8_t channel;
     uint8_t power;
+    uint8_t flags;
 #ifdef CONFIG_OEPL_SUBGIG_SUPPORT
     uint8_t subghzchannel;
 #endif

--- a/ESP32_AP-Flasher/src/leds.cpp
+++ b/ESP32_AP-Flasher/src/leds.cpp
@@ -185,7 +185,7 @@ void quickBlink(uint8_t repeat) {
     for (int i = 0; i < repeat; i++) {
         struct ledInstruction* mono = new struct ledInstruction;
 #ifdef HAS_TFT
-        mono->value = 255;
+        mono->value = maxledbrightness ? 255 : 0;
 #else
         mono->value = maxledbrightness;
 #endif

--- a/ESP32_AP-Flasher/src/serialap.cpp
+++ b/ESP32_AP-Flasher/src/serialap.cpp
@@ -323,6 +323,7 @@ bool sendChannelPower(struct espSetChannelPower* scp) {
     if (apInfo.state == AP_STATE_NORADIO) return true;
     if ((apInfo.state != AP_STATE_ONLINE) && (apInfo.state != AP_STATE_COMING_ONLINE)) return false;
     if (!txStart()) return false;
+    scp->flags = (config.led > 0) ? ESP_SCP_FLAG_LED : 0;
     addCRC(scp, sizeof(struct espSetChannelPower));
     for (uint8_t attempt = 0; attempt < 5; attempt++) {
         cmdReplyValue = CMD_REPLY_WAIT;

--- a/ESP32_AP-Flasher/src/web.cpp
+++ b/ESP32_AP-Flasher/src/web.cpp
@@ -591,6 +591,9 @@ void init_web() {
         if (request->hasParam("led", true)) {
             config.led = static_cast<uint8_t>(request->getParam("led", true)->value().toInt());
             updateBrightnessFromConfig();
+            // sendChannelPower also carries the LED flag, pushing the change to
+            // the C6 live rather than only at the next reboot.
+            sendChannelPower(&curChannel);
         }
         if (request->hasParam("tft", true)) {
             config.tft = static_cast<uint8_t>(request->getParam("tft", true)->value().toInt());

--- a/oepl-esp-ap-proto.h
+++ b/oepl-esp-ap-proto.h
@@ -14,10 +14,15 @@ struct espXferComplete {
     uint8_t src[8];
 } __packed;
 
+// flags bit 0: the AP mirrors its LED on/off setting here so the radio
+// co-processor can silence its own activity LED. Other bits reserved.
+#define ESP_SCP_FLAG_LED (1 << 0)
+
 struct espSetChannelPower {
     uint8_t checksum;
     uint8_t channel;
     uint8_t power;
+    uint8_t flags;
 #ifdef HAS_SUBGHZ
     uint8_t subghzchannel;
 #endif


### PR DESCRIPTION
## Make the yellow AP activity LED honor "LED off"

On `ESP32_S3_16_8_YELLOW_AP` the radio-activity LED kept blinking with the LED set to off. Two separate LEDs across two firmwares were ignoring the setting:

- S3: `quickBlink()` hardcoded full brightness under `HAS_TFT`. Now gated on `maxledbrightness`.
- C6: blinks its own GPIO LED, oblivious to `config.led`. Added a `flags` byte to `SCP>` (`espSetChannelPower`); S3 sends `config.led` state, C6 gates `led_flash()` on it.